### PR TITLE
pkg/save: Fix max lvl habitats endlessly updating

### DIFF
--- a/pkg/save/json.go
+++ b/pkg/save/json.go
@@ -86,7 +86,7 @@ type HabitatProductionLogic struct {
 	Storage                 map[string]json.Number `json:"storage"`
 	MaxInhabitants          int64                  `json:"maxInhabitants"`
 	HabitatLevel            int64                  `json:"habitatLevel"`
-	Upgrade                 string                 `json:"upgrade"`
+	Upgrade                 json.RawMessage        `json:"upgrade"`
 	Downgrade               json.RawMessage        `json:"downgrade"`
 	PowerNeededForTenPeople json.Number            `json:"powerNeededForTenPeople"`
 	TargetInhabitants       json.Number            `json:"targetInhabitants"`


### PR DESCRIPTION
The json declared it as a string, but on max lvl upgrade is null instead of an empty string.

Part of fixing #80