### PR TITLE
Makefile: Add fmt and validate commands 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,12 @@ jobs:
     with:
       cmd: hack/unit-tests.sh
 
+  validate:
+    uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
+    with:
+      cache: false
+      cmd: "make validate"
+
   build:
     uses: heathcliff26/ci/.github/workflows/golang-fyne-build.yaml@main
     needs:

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,18 @@ build-all:
 coverprofile:
 	hack/coverprofile.sh
 
+fmt:
+	gofmt -s -w ./cmd ./pkg
+
+validate:
+	hack/validate.sh
+
 .PHONY: \
 	default \
 	build \
 	test \
 	lint \
 	coverprofile \
+	fmt \
+	validate \
 	$(NULL)

--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Check if source code is formatted"
+make fmt
+rc=0
+git update-index --refresh && git diff-index --quiet HEAD -- || rc=1
+if [ $rc -ne 0 ]; then
+    echo "FATAL: Need to run \"make fmt\""
+    exit 1
+fi


### PR DESCRIPTION
Add a command to format the go code.
Add a command to validate that the workspace is clean.

Ensure code is always properly formatted by adding the validate step to ci.
