### PR TITLE
save: Use build tags for deciding default path during compile

### DIFF
--- a/pkg/save/utils.go
+++ b/pkg/save/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 )
@@ -27,27 +26,6 @@ func SpaceshipParts() []string {
 	list := make([]string, len(spaceshipParts))
 	copy(list, spaceshipParts)
 	return list
-}
-
-func DefaultSaveLocation() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	var path string
-	switch runtime.GOOS {
-	case "windows":
-		path = saveFolderWindows(home)
-	case "linux":
-		path = filepath.Join(home, "snap/steam/common/.local/share/Steam/steamapps/compatdata/1511460/pfx/drive_c/users/steamuser/")
-		path = saveFolderWindows(path)
-	}
-	if _, err := os.Stat(path); path != "" && !os.IsNotExist(err) {
-		return path, nil
-	} else {
-		return home, nil
-	}
 }
 
 func saveFolderWindows(root string) string {

--- a/pkg/save/utils_linux.go
+++ b/pkg/save/utils_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package save
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DefaultSaveLocation() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(home, "snap/steam/common/.local/share/Steam/steamapps/compatdata/1511460/pfx/drive_c/users/steamuser/")
+	path = saveFolderWindows(path)
+	if _, err := os.Stat(path); path != "" && !os.IsNotExist(err) {
+		return path, nil
+	} else {
+		return home, nil
+	}
+}

--- a/pkg/save/utils_windows.go
+++ b/pkg/save/utils_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package save
+
+import (
+	"os"
+)
+
+func DefaultSaveLocation() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	path := saveFolderWindows(home)
+	if _, err := os.Stat(path); path != "" && !os.IsNotExist(err) {
+		return path, nil
+	} else {
+		return home, nil
+	}
+}


### PR DESCRIPTION
Switch from deciding the os specific path at runtime to during compile time.