### PR TITLE
save: Add multiple location on linux for save folder

### DIFF
--- a/pkg/save/utils_linux.go
+++ b/pkg/save/utils_linux.go
@@ -13,11 +13,18 @@ func DefaultSaveLocation() (string, error) {
 		return "", err
 	}
 
-	path := filepath.Join(home, "snap/steam/common/.local/share/Steam/steamapps/compatdata/1511460/pfx/drive_c/users/steamuser/")
-	path = saveFolderWindows(path)
-	if _, err := os.Stat(path); path != "" && !os.IsNotExist(err) {
-		return path, nil
-	} else {
-		return home, nil
+	paths := []string{
+		".local/share/Steam/steamapps/compatdata/1511460/pfx/drive_c/users/steamuser/",
+		"snap/steam/common/.local/share/Steam/steamapps/compatdata/1511460/pfx/drive_c/users/steamuser/",
+		".var/app/com.valvesoftware.Steam/data/Steam/steamapps/compatdata/1511460/pfx/drive_c/users/steamuser/",
 	}
+
+	for _, path := range paths {
+		path = filepath.Join(home, path)
+		path = saveFolderWindows(path)
+		if _, err := os.Stat(path); path != "" && !os.IsNotExist(err) {
+			return path, nil
+		}
+	}
+	return home, nil
 }


### PR DESCRIPTION
On linux the steam path is different depending on if steam is installed directly or via flatpak/snap.