### PR TITLE
save: Use windows style newlines when saving

### DIFF
--- a/pkg/save/utils.go
+++ b/pkg/save/utils.go
@@ -85,5 +85,7 @@ func marshalJSON(v any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return buf.String(), nil
+
+	res := buf.String()
+	return strings.ReplaceAll(res, "\n", "\r\n"), nil
 }

--- a/pkg/save/utils_test.go
+++ b/pkg/save/utils_test.go
@@ -162,6 +162,10 @@ func TestMarshalJSON(t *testing.T) {
 	input += "  \"<disabledDueToMods>k__BackingField\": 0\n"
 	input += "}\n"
 
+	output := "{\r\n"
+	output += "  \"<disabledDueToMods>k__BackingField\": 0\r\n"
+	output += "}\r\n"
+
 	assert := assert.New(t)
 
 	var data json.RawMessage
@@ -170,5 +174,5 @@ func TestMarshalJSON(t *testing.T) {
 	assert.Nil(err)
 	res, err := marshalJSON(data)
 	assert.Nil(err)
-	assert.Equal(input, res)
+	assert.Equal(output, res)
 }


### PR DESCRIPTION
InfraSpace uses windows style newlines in save file. Ensure that the outputed save file retains this.