### PR TITLE
Makefile: Simplify call to build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 SHELL := bash
 
-GO_LD_FLAGS ?= "-w -s"
-
 default: build
 
 lint:
@@ -11,7 +9,7 @@ test:
 	go test -v -coverprofile=coverprofile.out -coverpkg "./pkg/..." ./...
 
 build:
-	( GOOS="$(GOOS)" GOARCH="$(GOARCH)" GO_BUILD_FLAGS=$(GO_BUILD_FLAGS) hack/build.sh )
+	hack/build.sh
 
 build-all:
 	hack/build-all.sh

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -9,7 +9,7 @@ bin_dir="${base_dir}/bin"
 GOOS="${GOOS:-$(go env GOOS)}"
 GOARCH="${GOARCH:-$(go env GOARCH)}"
 
-GO_LD_FLAGS="${GO_LD_FLAGS:-"-w -s"}"
+GO_LD_FLAGS="${GO_LD_FLAGS:-"-s"}"
 
 output_name="${bin_dir}/infraspace-savegame-editor"
 


### PR DESCRIPTION
Remove unnecessary enviroment variables and simply call script directly. Drop unused -w ldflag.