### PR TITLE
CI: Do not wait for unit-tests for running build jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,7 @@ jobs:
       contents: read
     needs:
       - lint
-      - unit-tests-linux
-      - unit-tests-windows
+      - validate
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>