### PR TITLE
Makefile: Move target description to above them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,39 +3,51 @@ SHELL := bash
 # The default target
 default: build
 
-lint: ## Run linter
+# Run linter
+lint:
 	golangci-lint run -v --timeout 300s
 
-test: ## Run unit-tests
+# Run unit-tests
+test:
 	go test -v -coverprofile=coverprofile.out -coverpkg "./pkg/..." ./...
 
-build: ## Build the binary
+# Build the binary
+build:
 	hack/build.sh
 
-build-all: ## Build the project for all supported platforms
+# Build the project for all supported platforms
+build-all:
 	hack/build-all.sh
 
-coverprofile: ## Generate coverage profile
+# Generate coverage profile
+coverprofile:
 	hack/coverprofile.sh
 
-fmt: ## Format the code
+# Format the code
+fmt:
 	gofmt -s -w ./cmd ./pkg
 
-validate: ## Validate that the codebase is clean
+# Validate that the codebase is clean
+validate:
 	hack/validate.sh
 
-update-deps: ## Update project dependencies
+# Update project dependencies
+update-deps:
 	hack/update-deps.sh
 
-gosec: ## Scan code for vulnerabilities using gosec
+# Scan code for vulnerabilities using gosec
+gosec:
 	gosec ./...
 
-clean: ## Clean up build artifacts
+# Clean up build artifacts
+clean:
 	hack/clean.sh
 
-help: ## Show this help message
+# Show this help message
+help:
 	@echo "Available targets:"
-	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@echo ""
+	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
 	@echo ""
 	@echo "Run 'make <target>' to execute a specific target."
 


### PR DESCRIPTION
To improve readability and maintainability, move the descriptions used by make
help to the top of their targets.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>