### PR TITLE
install: Fully install app on system

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ Notes:
 - You can reset all changes by pressing reset. This will cause the GUI to reset all selections made
 - If you do not want to create a backup every time you save, unselect `File -> Backup`
 
+## Installation
+
+### Download binary
+
+1. Download the [latest release](https://github.com/heathcliff26/infraspace-savegame-editor/releases/latest)
+2. Unpack the archive
+3. Install the app for your user by running:
+   - You can install it globally by running the script with `sudo`
+```bash
+./install.sh -i
+```
+
+#### Uninstalling
+
+1. Switch to the folder where you have the installation script
+2. Uninstall by running:
+   - Run as `sudo` if you installed it globally
+```bash
+./install.sh -u
+```
+3. Delete the folder.
+
 ## Images
 
 ### Main Window

--- a/packages/install.sh
+++ b/packages/install.sh
@@ -3,7 +3,12 @@
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)"
 
 APP_ID="io.github.heathcliff26.infraspace-savegame-editor"
-DESKTOP_FILE_TARGET="${HOME}/.local/share/applications/${APP_ID}.desktop"
+BINARY="infraspace-savegame-editor"
+
+bin_dir="$HOME/.local/bin"
+if [ "$(whoami)" == "root" ]; then
+    bin_dir="/usr/local/bin"
+fi
 
 help() {
     echo "Integrate InfraSpace Savegame Editor with common desktop environments."
@@ -14,21 +19,25 @@ help() {
 }
 
 install() {
-    sed -e "s|@BASE_DIR|${base_dir}|g" "${base_dir}/${APP_ID}.desktop" >"${DESKTOP_FILE_TARGET}"
-    echo "Created file: ${DESKTOP_FILE_TARGET}"
+    echo "Installing binary to ${bin_dir}/${BINARY}"
+    cp "${base_dir}/${BINARY}" "${bin_dir}/${BINARY}"
 
-    if command -v xdg-desktop-menu >/dev/null 2>&1; then
-        echo "Forcing desktop menu update"
-        xdg-desktop-menu forceupdate
-        xdg-icon-resource forceupdate
-    else
-        echo "The app will not show up in the menu until the session is restarted"
-    fi
+    echo "Installing desktop file"
+    xdg-desktop-menu install "${base_dir}/${APP_ID}.desktop"
+
+    echo "Installing icon"
+    xdg-icon-resource install --size 512 "${base_dir}/${APP_ID}.png"
+
+    xdg-desktop-menu forceupdate
 }
 
 uninstall() {
-    rm "${DESKTOP_FILE_TARGET}"
-    echo "Removed: ${DESKTOP_FILE_TARGET}"
+    echo "Removing binary"
+    rm "${bin_dir}/${BINARY}"
+
+    echo "Removing desktop file and icon"
+    xdg-desktop-menu uninstall "${APP_ID}.desktop"
+    xdg-icon-resource uninstall --size 512 "${APP_ID}.png"
 }
 
 while [[ "$#" -gt 0 ]]; do

--- a/packages/io.github.heathcliff26.infraspace-savegame-editor.desktop
+++ b/packages/io.github.heathcliff26.infraspace-savegame-editor.desktop
@@ -6,6 +6,6 @@ Comment=A minesweeper implementation in golang
 Categories=Utility;
 Keywords=infraspace;
 
-Icon=@BASE_DIR/io.github.heathcliff26.infraspace-savegame-editor.png
-Exec=@BASE_DIR/infraspace-savegame-editor
+Icon=io.github.heathcliff26.infraspace-savegame-editor
+Exec=infraspace-savegame-editor
 Terminal=false


### PR DESCRIPTION
Instead of only installing the desktop file, install icons and binary on the system.
Ensure the script works for user and global installation. Add documentation for installation to README.md.